### PR TITLE
Ignore 100 in magic numbers

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -90,10 +90,12 @@ const rules = {
   'linebreak-style': ['error', 'unix'],
   'no-case-declarations': 'off',
   'no-console': ['error', { allow: ['error', 'warn'] }],
+  'eol-last': ['error', 'always'],
   'no-magic-numbers': ['error', {
     ignoreArrayIndexes: true,
-    ignore: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 60]  // 60 is often used for seconds
+    ignore: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 60, 100]  // 60 is often used for seconds, 100 is often used for percentage
   }],
+  'no-trailing-spaces': 'warn',
   'no-use-before-define': 'off',
   'padding-line-between-statements': ['error', 
     { blankLine: 'always', prev: 'function', next: '*' },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-yenz",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Jens' ESLint Configuration",
   "main": "index.mjs",
   "keywords": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enforced a newline at the end of files.
  * Added a warning for trailing whitespace at the end of lines.
  * Allowed the number 100 in addition to 60 as exceptions for magic numbers.

* **Chores**
  * Updated the package version to 9.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->